### PR TITLE
Backoff retry support and RoutePlan API

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/onfleet/gonfleet/service/routePlan"
 	"time"
 
 	"github.com/onfleet/gonfleet/netwrk"
@@ -41,6 +42,7 @@ type API struct {
 	Webhooks         *webhook.Client
 	Workers          *worker.Client
 	ManifestProvider *manifest.Client
+	RoutePlans       *routePlan.Client
 }
 
 // InitParams accepts user provided overrides to be set on Config
@@ -148,6 +150,12 @@ func New(apiKey string, params *InitParams) (*API, error) {
 		apiKey,
 		rlHttpClient,
 		fullBaseUrl+"/workers",
+		netwrk.Call,
+	)
+	api.RoutePlans = routePlan.Plug(
+		apiKey,
+		rlHttpClient,
+		fullBaseUrl+"/routePlans",
 		netwrk.Call,
 	)
 

--- a/routePlan.go
+++ b/routePlan.go
@@ -1,0 +1,65 @@
+package onfleet
+
+type PositionEnum string
+
+const (
+	PositionEnumHub            PositionEnum = "HUB"
+	PositionEnumWorkerLocation PositionEnum = "WORKER_LOCATION"
+	PositionEnumWorkerAddress  PositionEnum = "WORKER_ADDRESS"
+)
+
+type RoutePlanParams struct {
+	Name          string       `json:"name"`
+	StartTime     int64        `json:"startTime"`
+	TaskIds       []string     `json:"tasks,omitempty"`
+	Color         string       `json:"color,omitempty"`
+	VehicleType   string       `json:"vehicleType,omitempty"`
+	Worker        string       `json:"worker,omitempty"`
+	Team          string       `json:"team,omitempty"`
+	StartAt       PositionEnum `json:"start,omitempty"`
+	EndAt         PositionEnum `json:"end,omitempty"`
+	StartingHubId string       `json:"startingHubId,omitempty"`
+	EndingHubId   string       `json:"endingHubId,omitempty"`
+	EndTime       int64        `json:"endTime,omitempty"`
+	Timezone      string       `json:"timezone,omitempty"`
+}
+
+type RoutePlan struct {
+	Id               string   `json:"id"`
+	Name             string   `json:"name"`
+	State            string   `json:"state"`
+	Color            string   `json:"color"`
+	Tasks            []string `json:"tasks"`
+	Organization     string   `json:"organization"`
+	Team             *string  `json:"team"`
+	Worker           string   `json:"worker"`
+	VehicleType      string   `json:"vehicleType"`
+	StartTime        int64    `json:"startTime"`
+	EndTime          *int64   `json:"endTime"`
+	ActualStartTime  *int64   `json:"actualStartTime"`
+	ActualEndTime    *int64   `json:"actualEndTime"`
+	StartingHubId    *string  `json:"startingHubId"`
+	EndingHubId      *string  `json:"endingHubId"`
+	ShortId          string   `json:"shortId"`
+	TimeCreated      int64    `json:"timeCreated"`
+	TimeLastModified int64    `json:"timeLastModified"`
+}
+
+type RoutePlanListQueryParams struct {
+	WorkerId        string `json:"workerId,omitempty"`
+	StartTimeTo     int64  `json:"startTimeTo,omitempty"`
+	StartTimeFrom   int64  `json:"startTimeFrom,omitempty"`
+	CreatedTimeTo   int64  `json:"createdTimeTo,omitempty"`
+	CreatedTimeFrom int64  `json:"createdTimeFrom,omitempty"`
+	HasTasks        bool   `json:"hasTasks,omitempty"`
+	Limit           int64  `json:"limit,omitempty"`
+}
+
+type RoutePlanAddTasksParams struct {
+	Tasks []string `json:"tasks"`
+}
+
+type RoutePlansPaginated struct {
+	LastId     string      `json:"lastId,omitempty"`
+	RoutePlans []RoutePlan `json:"routePlans"`
+}

--- a/service/routePlan/client.go
+++ b/service/routePlan/client.go
@@ -1,0 +1,119 @@
+package routePlan
+
+import (
+	"net/http"
+
+	"github.com/onfleet/gonfleet"
+	"github.com/onfleet/gonfleet/netwrk"
+)
+
+type Client struct {
+	apiKey       string
+	rlHttpClient *netwrk.RlHttpClient
+	url          string
+	call         netwrk.Caller
+}
+
+func Plug(apiKey string, rlHttpClient *netwrk.RlHttpClient, url string, call netwrk.Caller) *Client {
+	return &Client{
+		apiKey:       apiKey,
+		rlHttpClient: rlHttpClient,
+		url:          url,
+		call:         call,
+	}
+}
+
+// Reference https://docs.onfleet.com/reference/post-create-route-plan
+func (c *Client) Create(params onfleet.RoutePlanParams) (onfleet.RoutePlan, error) {
+	routePlan := onfleet.RoutePlan{}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPost,
+		c.url,
+		nil,
+		nil,
+		params,
+		&routePlan,
+	)
+	return routePlan, err
+}
+
+// Reference https://docs.onfleet.com/reference/update-route-plan
+func (c *Client) Update(routePlanId string, params onfleet.RoutePlanParams) (onfleet.RoutePlan, error) {
+	routePlan := onfleet.RoutePlan{}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{routePlanId},
+		nil,
+		params,
+		&routePlan,
+	)
+	return routePlan, err
+}
+
+// Reference https://docs.onfleet.com/reference/add-tasks-to-route-plan
+func (c *Client) AddTasks(routePlanId string, params onfleet.RoutePlanAddTasksParams) (onfleet.RoutePlan, error) {
+	routePlan := onfleet.RoutePlan{}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{routePlanId},
+		nil,
+		params,
+		&routePlan,
+	)
+	return routePlan, err
+}
+
+// Reference https://docs.onfleet.com/reference/get-routeplan-by-id
+func (c *Client) Get(routePlanId string) (onfleet.RoutePlan, error) {
+	routePlan := onfleet.RoutePlan{}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodGet,
+		c.url,
+		[]string{routePlanId},
+		nil,
+		nil,
+		&routePlan,
+	)
+	return routePlan, err
+}
+
+// Reference https://docs.onfleet.com/reference/get-route-plan
+func (c *Client) List(params onfleet.RoutePlanListQueryParams) (onfleet.RoutePlansPaginated, error) {
+	paginatedRoutePlans := onfleet.RoutePlansPaginated{}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodGet,
+		c.url,
+		[]string{"all"},
+		params,
+		nil,
+		&paginatedRoutePlans,
+	)
+	return paginatedRoutePlans, err
+}
+
+// Reference https://docs.onfleet.com/reference/delete-routePlan
+func (c *Client) Delete(routePlanId string) error {
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodDelete,
+		c.url,
+		[]string{routePlanId},
+		nil,
+		nil,
+		nil,
+	)
+	return err
+}

--- a/task.go
+++ b/task.go
@@ -39,6 +39,7 @@ type Task struct {
 	TrackingUrl      string    `json:"trackingURL"`
 	TrackingViewed   bool      `json:"trackingViewed"`
 	Worker           *string   `json:"worker"`
+	RoutePlan        *string   `json:"routePlan"`
 }
 
 type TasksPaginated struct {


### PR DESCRIPTION
* Add a backoff and retry mechanism on 429 and 412 errors from the API (following a support thread with Ethan).
* Add support for the new RoutePlan API.