### PR TITLE
Atomic metadata operations, Task listing by container, route plan fixes

### DIFF
--- a/routePlan.go
+++ b/routePlan.go
@@ -58,8 +58,3 @@ type RoutePlanListQueryParams struct {
 type RoutePlanAddTasksParams struct {
 	Tasks []string `json:"tasks"`
 }
-
-type RoutePlansPaginated struct {
-	LastId     string      `json:"lastId,omitempty"`
-	RoutePlans []RoutePlan `json:"routePlans"`
-}

--- a/service/admin/client.go
+++ b/service/admin/client.go
@@ -101,3 +101,47 @@ func (c *Client) Delete(adminId string) error {
 	)
 	return err
 }
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataSet atomically adds or updates metadata fields without affecting other metadata
+func (c *Client) MetadataSet(adminId string, metadata ...onfleet.Metadata) (onfleet.Admin, error) {
+	admin := onfleet.Admin{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$set": metadata,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{adminId},
+		nil,
+		body,
+		&admin,
+	)
+	return admin, err
+}
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataPop atomically removes metadata fields without affecting other metadata
+func (c *Client) MetadataPop(adminId string, names ...string) (onfleet.Admin, error) {
+	admin := onfleet.Admin{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$pop": names,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{adminId},
+		nil,
+		body,
+		&admin,
+	)
+	return admin, err
+}

--- a/service/admin/client.go
+++ b/service/admin/client.go
@@ -128,9 +128,15 @@ func (c *Client) MetadataSet(adminId string, metadata ...onfleet.Metadata) (onfl
 // MetadataPop atomically removes metadata fields without affecting other metadata
 func (c *Client) MetadataPop(adminId string, names ...string) (onfleet.Admin, error) {
 	admin := onfleet.Admin{}
+
+	popArray := make([]map[string]string, len(names))
+	for i, name := range names {
+		popArray[i] = map[string]string{"name": name}
+	}
+
 	body := map[string]any{
 		"metadata": map[string]any{
-			"$pop": names,
+			"$pop": popArray,
 		},
 	}
 	err := c.call(

--- a/service/destination/client.go
+++ b/service/destination/client.go
@@ -97,9 +97,15 @@ func (c *Client) MetadataSet(destinationId string, metadata ...onfleet.Metadata)
 // MetadataPop atomically removes metadata fields without affecting other metadata
 func (c *Client) MetadataPop(destinationId string, names ...string) (onfleet.Destination, error) {
 	destination := onfleet.Destination{}
+
+	popArray := make([]map[string]string, len(names))
+	for i, name := range names {
+		popArray[i] = map[string]string{"name": name}
+	}
+
 	body := map[string]any{
 		"metadata": map[string]any{
-			"$pop": names,
+			"$pop": popArray,
 		},
 	}
 	err := c.call(

--- a/service/destination/client.go
+++ b/service/destination/client.go
@@ -70,3 +70,47 @@ func (c *Client) ListWithMetadataQuery(metadata []onfleet.Metadata) ([]onfleet.D
 	)
 	return destinations, err
 }
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataSet atomically adds or updates metadata fields without affecting other metadata
+func (c *Client) MetadataSet(destinationId string, metadata ...onfleet.Metadata) (onfleet.Destination, error) {
+	destination := onfleet.Destination{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$set": metadata,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{destinationId},
+		nil,
+		body,
+		&destination,
+	)
+	return destination, err
+}
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataPop atomically removes metadata fields without affecting other metadata
+func (c *Client) MetadataPop(destinationId string, names ...string) (onfleet.Destination, error) {
+	destination := onfleet.Destination{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$pop": names,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{destinationId},
+		nil,
+		body,
+		&destination,
+	)
+	return destination, err
+}

--- a/service/recipient/client.go
+++ b/service/recipient/client.go
@@ -102,3 +102,47 @@ func (c *Client) ListWithMetadataQuery(metadata []onfleet.Metadata) ([]onfleet.R
 	)
 	return recipients, err
 }
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataSet atomically adds or updates metadata fields without affecting other metadata
+func (c *Client) MetadataSet(recipientId string, metadata ...onfleet.Metadata) (onfleet.Recipient, error) {
+	recipient := onfleet.Recipient{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$set": metadata,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{recipientId},
+		nil,
+		body,
+		&recipient,
+	)
+	return recipient, err
+}
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataPop atomically removes metadata fields without affecting other metadata
+func (c *Client) MetadataPop(recipientId string, names ...string) (onfleet.Recipient, error) {
+	recipient := onfleet.Recipient{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$pop": names,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{recipientId},
+		nil,
+		body,
+		&recipient,
+	)
+	return recipient, err
+}

--- a/service/recipient/client.go
+++ b/service/recipient/client.go
@@ -129,9 +129,15 @@ func (c *Client) MetadataSet(recipientId string, metadata ...onfleet.Metadata) (
 // MetadataPop atomically removes metadata fields without affecting other metadata
 func (c *Client) MetadataPop(recipientId string, names ...string) (onfleet.Recipient, error) {
 	recipient := onfleet.Recipient{}
+
+	popArray := make([]map[string]string, len(names))
+	for i, name := range names {
+		popArray[i] = map[string]string{"name": name}
+	}
+
 	body := map[string]any{
 		"metadata": map[string]any{
-			"$pop": names,
+			"$pop": popArray,
 		},
 	}
 	err := c.call(

--- a/service/routePlan/client.go
+++ b/service/routePlan/client.go
@@ -63,7 +63,7 @@ func (c *Client) AddTasks(routePlanId string, params onfleet.RoutePlanAddTasksPa
 		c.rlHttpClient,
 		http.MethodPut,
 		c.url,
-		[]string{routePlanId},
+		[]string{routePlanId, "tasks"},
 		nil,
 		params,
 		&routePlan,
@@ -88,8 +88,8 @@ func (c *Client) Get(routePlanId string) (onfleet.RoutePlan, error) {
 }
 
 // Reference https://docs.onfleet.com/reference/get-route-plan
-func (c *Client) List(params onfleet.RoutePlanListQueryParams) (onfleet.RoutePlansPaginated, error) {
-	paginatedRoutePlans := onfleet.RoutePlansPaginated{}
+func (c *Client) List(params onfleet.RoutePlanListQueryParams) ([]onfleet.RoutePlan, error) {
+	var routePlans []onfleet.RoutePlan
 	err := c.call(
 		c.apiKey,
 		c.rlHttpClient,
@@ -98,9 +98,9 @@ func (c *Client) List(params onfleet.RoutePlanListQueryParams) (onfleet.RoutePla
 		nil,
 		params,
 		nil,
-		&paginatedRoutePlans,
+		&routePlans,
 	)
-	return paginatedRoutePlans, err
+	return routePlans, err
 }
 
 // Reference https://docs.onfleet.com/reference/delete-routePlan

--- a/service/routePlan/client.go
+++ b/service/routePlan/client.go
@@ -95,7 +95,7 @@ func (c *Client) List(params onfleet.RoutePlanListQueryParams) (onfleet.RoutePla
 		c.rlHttpClient,
 		http.MethodGet,
 		c.url,
-		[]string{"all"},
+		nil,
 		params,
 		nil,
 		&paginatedRoutePlans,

--- a/service/routePlan/client_test.go
+++ b/service/routePlan/client_test.go
@@ -13,12 +13,12 @@ func TestClient_Create(t *testing.T) {
 	defer testingutil.CleanupTest(t, mockClient)
 
 	expectedRoutePlan := testingutil.GetSampleRoutePlan()
-	mockClient.AddResponse("/route-plans", testingutil.MockResponse{
+	mockClient.AddResponse("/routePlans", testingutil.MockResponse{
 		StatusCode: 201,
 		Body:       expectedRoutePlan,
 	})
 
-	client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+	client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 	params := onfleet.RoutePlanParams{
 		Name:          "Evening Delivery Route",
@@ -43,7 +43,7 @@ func TestClient_Create(t *testing.T) {
 	assert.Equal(t, expectedRoutePlan.Name, routePlan.Name)
 	assert.Equal(t, expectedRoutePlan.VehicleType, routePlan.VehicleType)
 
-	mockClient.AssertRequestMade("POST", "/route-plans")
+	mockClient.AssertRequestMade("POST", "/routePlans")
 	mockClient.AssertBasicAuth("test_api_key")
 }
 
@@ -52,12 +52,12 @@ func TestClient_Get(t *testing.T) {
 	defer testingutil.CleanupTest(t, mockClient)
 
 	expectedRoutePlan := testingutil.GetSampleRoutePlan()
-	mockClient.AddResponse("/route-plans/routeplan_123", testingutil.MockResponse{
+	mockClient.AddResponse("/routePlans/routeplan_123", testingutil.MockResponse{
 		StatusCode: 200,
 		Body:       expectedRoutePlan,
 	})
 
-	client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+	client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 	routePlan, err := client.Get("routeplan_123")
 
@@ -67,7 +67,7 @@ func TestClient_Get(t *testing.T) {
 	assert.Equal(t, expectedRoutePlan.State, routePlan.State)
 	assert.Len(t, routePlan.Tasks, 3)
 
-	mockClient.AssertRequestMade("GET", "/route-plans/routeplan_123")
+	mockClient.AssertRequestMade("GET", "/routePlans/routeplan_123")
 }
 
 func TestClient_Update(t *testing.T) {
@@ -78,12 +78,12 @@ func TestClient_Update(t *testing.T) {
 	expectedRoutePlan.Name = "Updated Morning Route"
 	expectedRoutePlan.Color = "#00FF00"
 
-	mockClient.AddResponse("/route-plans/routeplan_123", testingutil.MockResponse{
+	mockClient.AddResponse("/routePlans/routeplan_123", testingutil.MockResponse{
 		StatusCode: 200,
 		Body:       expectedRoutePlan,
 	})
 
-	client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+	client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 	params := onfleet.RoutePlanParams{
 		Name:        "Updated Morning Route",
@@ -99,7 +99,7 @@ func TestClient_Update(t *testing.T) {
 	assert.Equal(t, "Updated Morning Route", routePlan.Name)
 	assert.Equal(t, "#00FF00", routePlan.Color)
 
-	mockClient.AssertRequestMade("PUT", "/route-plans/routeplan_123")
+	mockClient.AssertRequestMade("PUT", "/routePlans/routeplan_123")
 }
 
 func TestClient_AddTasks(t *testing.T) {
@@ -109,12 +109,12 @@ func TestClient_AddTasks(t *testing.T) {
 	expectedRoutePlan := testingutil.GetSampleRoutePlan()
 	expectedRoutePlan.Tasks = []string{"task_111", "task_222", "task_333", "task_444", "task_555"}
 
-	mockClient.AddResponse("/route-plans/routeplan_123", testingutil.MockResponse{
+	mockClient.AddResponse("/routePlans/routeplan_123", testingutil.MockResponse{
 		StatusCode: 200,
 		Body:       expectedRoutePlan,
 	})
 
-	client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+	client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 	params := onfleet.RoutePlanAddTasksParams{
 		Tasks: []string{"task_444", "task_555"},
@@ -128,28 +128,23 @@ func TestClient_AddTasks(t *testing.T) {
 	assert.Equal(t, "task_444", routePlan.Tasks[3])
 	assert.Equal(t, "task_555", routePlan.Tasks[4])
 
-	mockClient.AssertRequestMade("PUT", "/route-plans/routeplan_123")
+	mockClient.AssertRequestMade("PUT", "/routePlans/routeplan_123")
 }
 
 func TestClient_List(t *testing.T) {
 	mockClient := testingutil.SetupTest(t)
 	defer testingutil.CleanupTest(t, mockClient)
 
-	expectedRoutePlans := []onfleet.RoutePlan{
+	expectedResponse := []onfleet.RoutePlan{
 		testingutil.GetSampleRoutePlan(),
 	}
 
-	expectedResponse := onfleet.RoutePlansPaginated{
-		RoutePlans: expectedRoutePlans,
-		LastId:     "routeplan_123",
-	}
-
-	mockClient.AddResponse("/route-plans/all", testingutil.MockResponse{
+	mockClient.AddResponse("/routePlans", testingutil.MockResponse{
 		StatusCode: 200,
 		Body:       expectedResponse,
 	})
 
-	client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+	client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 	params := onfleet.RoutePlanListQueryParams{
 		WorkerId:        "worker_123",
@@ -161,31 +156,30 @@ func TestClient_List(t *testing.T) {
 		Limit:           10,
 	}
 
-	response, err := client.List(params)
+	RoutePlans, err := client.List(params)
 
 	assert.NoError(t, err)
-	assert.Len(t, response.RoutePlans, 1)
-	assert.Equal(t, expectedRoutePlans[0].Id, response.RoutePlans[0].Id)
-	assert.Equal(t, "routeplan_123", response.LastId)
+	assert.Len(t, RoutePlans, 1)
+	assert.Equal(t, expectedResponse[0].Id, RoutePlans[0].Id)
 
-	mockClient.AssertRequestMade("GET", "/route-plans/all")
+	mockClient.AssertRequestMade("GET", "/routePlans")
 }
 
 func TestClient_Delete(t *testing.T) {
 	mockClient := testingutil.SetupTest(t)
 	defer testingutil.CleanupTest(t, mockClient)
 
-	mockClient.AddResponse("/route-plans/routeplan_123", testingutil.MockResponse{
+	mockClient.AddResponse("/routePlans/routeplan_123", testingutil.MockResponse{
 		StatusCode: 200,
 		Body:       map[string]interface{}{"success": true},
 	})
 
-	client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+	client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 	err := client.Delete("routeplan_123")
 
 	assert.NoError(t, err)
-	mockClient.AssertRequestMade("DELETE", "/route-plans/routeplan_123")
+	mockClient.AssertRequestMade("DELETE", "/routePlans/routeplan_123")
 }
 
 func TestClient_VehicleTypes(t *testing.T) {
@@ -223,12 +217,12 @@ func TestClient_VehicleTypes(t *testing.T) {
 			expectedRoutePlan := testingutil.GetSampleRoutePlan()
 			expectedRoutePlan.VehicleType = tt.vehicleType
 
-			mockClient.AddResponse("/route-plans", testingutil.MockResponse{
+			mockClient.AddResponse("/routePlans", testingutil.MockResponse{
 				StatusCode: 201,
 				Body:       expectedRoutePlan,
 			})
 
-			client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+			client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 			params := onfleet.RoutePlanParams{
 				Name:        "Vehicle Type Test Route",
@@ -293,12 +287,12 @@ func TestClient_PositionTypes(t *testing.T) {
 				expectedRoutePlan.EndingHubId = nil
 			}
 
-			mockClient.AddResponse("/route-plans", testingutil.MockResponse{
+			mockClient.AddResponse("/routePlans", testingutil.MockResponse{
 				StatusCode: 201,
 				Body:       expectedRoutePlan,
 			})
 
-			client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+			client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 			params := onfleet.RoutePlanParams{
 				Name:          "Position Test Route",
@@ -351,12 +345,12 @@ func TestClient_RoutePlanStates(t *testing.T) {
 			expectedRoutePlan := testingutil.GetSampleRoutePlan()
 			expectedRoutePlan.State = tt.state
 
-			mockClient.AddResponse("/route-plans/routeplan_123", testingutil.MockResponse{
+			mockClient.AddResponse("/routePlans/routeplan_123", testingutil.MockResponse{
 				StatusCode: 200,
 				Body:       expectedRoutePlan,
 			})
 
-			client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+			client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 			routePlan, err := client.Get("routeplan_123")
 
@@ -377,7 +371,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 		{
 			name:       "create invalid start time",
 			method:     "POST",
-			url:        "/route-plans",
+			url:        "/routePlans",
 			statusCode: 400,
 			operation: func(client *Client) error {
 				_, err := client.Create(onfleet.RoutePlanParams{
@@ -390,7 +384,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 		{
 			name:       "create missing worker and team",
 			method:     "POST",
-			url:        "/route-plans",
+			url:        "/routePlans",
 			statusCode: 400,
 			operation: func(client *Client) error {
 				_, err := client.Create(onfleet.RoutePlanParams{
@@ -404,7 +398,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 		{
 			name:       "get not found",
 			method:     "GET",
-			url:        "/route-plans/nonexistent",
+			url:        "/routePlans/nonexistent",
 			statusCode: 404,
 			operation: func(client *Client) error {
 				_, err := client.Get("nonexistent")
@@ -414,7 +408,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 		{
 			name:       "update not found",
 			method:     "PUT",
-			url:        "/route-plans/nonexistent",
+			url:        "/routePlans/nonexistent",
 			statusCode: 404,
 			operation: func(client *Client) error {
 				_, err := client.Update("nonexistent", onfleet.RoutePlanParams{
@@ -427,7 +421,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 		{
 			name:       "add tasks to completed route plan",
 			method:     "PUT",
-			url:        "/route-plans/completed_123",
+			url:        "/routePlans/completed_123",
 			statusCode: 400,
 			operation: func(client *Client) error {
 				_, err := client.AddTasks("completed_123", onfleet.RoutePlanAddTasksParams{
@@ -439,7 +433,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 		{
 			name:       "delete active route plan",
 			method:     "DELETE",
-			url:        "/route-plans/active_123",
+			url:        "/routePlans/active_123",
 			statusCode: 409,
 			operation: func(client *Client) error {
 				return client.Delete("active_123")
@@ -448,7 +442,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 		{
 			name:       "list unauthorized",
 			method:     "GET",
-			url:        "/route-plans/all",
+			url:        "/routePlans/all",
 			statusCode: 401,
 			operation: func(client *Client) error {
 				_, err := client.List(onfleet.RoutePlanListQueryParams{})
@@ -467,7 +461,7 @@ func TestClient_ErrorScenarios(t *testing.T) {
 				Body:       testingutil.GetSampleErrorResponse(),
 			})
 
-			client := Plug("test_api_key", nil, "https://api.example.com/route-plans", mockClient.MockCaller)
+			client := Plug("test_api_key", nil, "https://api.example.com/routePlans", mockClient.MockCaller)
 
 			err := tt.operation(client)
 			assert.Error(t, err)

--- a/service/task/client.go
+++ b/service/task/client.go
@@ -228,3 +228,47 @@ func (c *Client) AutoAssignMulti(params onfleet.TaskAutoAssignMultiParams) (onfl
 	)
 	return autoAssignMulti, err
 }
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataSet atomically adds or updates metadata fields without affecting other metadata
+func (c *Client) MetadataSet(taskId string, metadata ...onfleet.Metadata) (onfleet.Task, error) {
+	task := onfleet.Task{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$set": metadata,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{taskId},
+		nil,
+		body,
+		&task,
+	)
+	return task, err
+}
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataPop atomically removes metadata fields without affecting other metadata
+func (c *Client) MetadataPop(taskId string, names ...string) (onfleet.Task, error) {
+	task := onfleet.Task{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$pop": names,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{taskId},
+		nil,
+		body,
+		&task,
+	)
+	return task, err
+}

--- a/service/task/client.go
+++ b/service/task/client.go
@@ -255,9 +255,15 @@ func (c *Client) MetadataSet(taskId string, metadata ...onfleet.Metadata) (onfle
 // MetadataPop atomically removes metadata fields without affecting other metadata
 func (c *Client) MetadataPop(taskId string, names ...string) (onfleet.Task, error) {
 	task := onfleet.Task{}
+
+	popArray := make([]map[string]string, len(names))
+	for i, name := range names {
+		popArray[i] = map[string]string{"name": name}
+	}
+
 	body := map[string]any{
 		"metadata": map[string]any{
-			"$pop": names,
+			"$pop": popArray,
 		},
 	}
 	err := c.call(

--- a/service/worker/client.go
+++ b/service/worker/client.go
@@ -213,3 +213,47 @@ func (c *Client) Delete(workerId string) error {
 	)
 	return err
 }
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataSet atomically adds or updates metadata fields without affecting other metadata
+func (c *Client) MetadataSet(workerId string, metadata ...onfleet.Metadata) (onfleet.Worker, error) {
+	worker := onfleet.Worker{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$set": metadata,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{workerId},
+		nil,
+		body,
+		&worker,
+	)
+	return worker, err
+}
+
+// Reference https://docs.onfleet.com/reference/metadata
+// MetadataPop atomically removes metadata fields without affecting other metadata
+func (c *Client) MetadataPop(workerId string, names ...string) (onfleet.Worker, error) {
+	worker := onfleet.Worker{}
+	body := map[string]any{
+		"metadata": map[string]any{
+			"$pop": names,
+		},
+	}
+	err := c.call(
+		c.apiKey,
+		c.rlHttpClient,
+		http.MethodPut,
+		c.url,
+		[]string{workerId},
+		nil,
+		body,
+		&worker,
+	)
+	return worker, err
+}

--- a/service/worker/client.go
+++ b/service/worker/client.go
@@ -240,9 +240,15 @@ func (c *Client) MetadataSet(workerId string, metadata ...onfleet.Metadata) (onf
 // MetadataPop atomically removes metadata fields without affecting other metadata
 func (c *Client) MetadataPop(workerId string, names ...string) (onfleet.Worker, error) {
 	worker := onfleet.Worker{}
+
+	popArray := make([]map[string]string, len(names))
+	for i, name := range names {
+		popArray[i] = map[string]string{"name": name}
+	}
+
 	body := map[string]any{
 		"metadata": map[string]any{
-			"$pop": names,
+			"$pop": popArray,
 		},
 	}
 	err := c.call(

--- a/task.go
+++ b/task.go
@@ -273,9 +273,11 @@ type TaskListQueryParams struct {
 	From int64 `json:"from,omitempty,string"`
 	To   int64 `json:"to,omitempty,string"`
 	// Used for pagination
-	LastId               string   `json:"lastId,omitempty"`
-	Worker               string   `json:"worker,omitempty"`
-	CompleteBeforeBefore int64    `json:"completeBeforeBefore,omitempty,string"`
-	CompleteAfterAfter   int64    `json:"completeAfterAfter,omitempty,string"`
-	Dependencies         []string `json:"dependencies,omitempty"`
+	LastId               string `json:"lastId,omitempty"`
+	State                string `json:"state,omitempty"`
+	Worker               string `json:"worker,omitempty"`
+	CompleteBeforeBefore int64  `json:"completeBeforeBefore,omitempty,string"`
+	CompleteAfterAfter   int64  `json:"completeAfterAfter,omitempty,string"`
+	Dependencies         string `json:"dependencies,omitempty"`
+	Containers           string `json:"containers,omitempty"`
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add atomic metadata operations, enhance task listing by container, and fix route plan functionalities across multiple services.
> 
>   - **Metadata Operations**:
>     - Add `MetadataSet` and `MetadataPop` functions to `client.go` in `service/admin`, `service/destination`, `service/recipient`, `service/task`, and `service/worker` for atomic metadata operations.
>     - Implement tests for `MetadataSet` and `MetadataPop` in `client_test.go` for `admin`, `destination`, `recipient`, `task`, and `worker`.
>   - **Task Listing**:
>     - Modify `List` function in `service/task/client.go` to support filtering by `state` and `containers`.
>     - Update `TaskListQueryParams` in `task.go` to include `state` and `containers` fields.
>     - Add tests for filtering tasks by `state` and `containers` in `service/task/client_test.go`.
>   - **Route Plan**:
>     - Remove `RoutePlansPaginated` struct from `routePlan.go`.
>     - Update `List` function in `service/routePlan/client.go` to return a slice of `RoutePlan` instead of `RoutePlansPaginated`.
>     - Adjust tests in `service/routePlan/client_test.go` to reflect changes in `List` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onfleet%2Fgonfleet&utm_source=github&utm_medium=referral)<sup> for 5c5f722d901591b19b5aba44195b83a5ff3b9543. You can [customize](https://app.ellipsis.dev/onfleet/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->